### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,15 @@ indent_size = 4
 indent_style = space
 indent_size = 4
 
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false
+
+[.github/{actions,workflows}/**/*.yml]
+indent_style = space
+indent_size = 2
+
 [Cargo.toml]
 indent_style = space
 indent_size = 4

--- a/.github/actions/cache-cargo-build/action.yml
+++ b/.github/actions/cache-cargo-build/action.yml
@@ -1,0 +1,23 @@
+name: Cache Cargo build
+description: Cache Cargo build
+inputs:
+  rustc-commit-hash:
+    description: Commit hash of the rustc version
+    required: true
+  profile:
+    description: Cargo profile used
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Cache Cargo build
+      uses: actions/cache@v2
+      with:
+        # https://doc.rust-lang.org/cargo/guide/build-cache.html
+        path: |
+          target/
+        key: cargo-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rustc-commit-hash }}-${{ inputs.profile }}-${{ hashFiles('**/Cargo.toml') }}-${{ github.sha }}
+        restore-keys: |
+          cargo-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rustc-commit-hash }}-${{ inputs.profile }}-${{ hashFiles('**/Cargo.toml') }}-
+          cargo-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rustc-commit-hash }}-${{ inputs.profile }}-
+          cargo-build-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rustc-commit-hash }}-

--- a/.github/actions/cache-cargo-home/action.yml
+++ b/.github/actions/cache-cargo-home/action.yml
@@ -1,0 +1,17 @@
+name: Cache Cargo home
+description: Cache Cargo home
+runs:
+  using: composite
+  steps:
+    - name: Cache Cargo home
+      uses: actions/cache@v2
+      with:
+        # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-home-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+        restore-keys: |
+          cargo-home-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/actions/cargo/action.yml
+++ b/.github/actions/cargo/action.yml
@@ -1,0 +1,60 @@
+name: Cargo
+description: Run Cargo command
+inputs:
+  command:
+    description: Cargo command to run (ex. `check` or `build`)
+    required: true
+  toolchain:
+    description: Toolchain to use (without the `+` sign, ex. `nightly`)
+    required: true
+  target:
+    description: Target triple
+    required: false
+  args:
+    description: Arguments for the cargo command
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Set host target triple
+      if: ${{ !inputs.target }}
+      run: |
+        case ${{ runner.os }} in
+          Linux)
+            case ${{ runner.arch }} in
+              X64)
+                CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu
+                ;;
+            esac
+            ;;
+          Windows)
+            case ${{ runner.arch }} in
+              X64)
+                CARGO_BUILD_TARGET=x86_64-pc-windows-msvc
+                ;;
+            esac
+            ;;
+          macOS)
+            case ${{ runner.arch }} in
+              X64)
+                CARGO_BUILD_TARGET=x86_64-apple-darwin
+                ;;
+            esac
+            ;;
+        esac
+        echo "CARGO_BUILD_TARGET=$CARGO_BUILD_TARGET" >> $GITHUB_ENV
+      shell: bash
+    - name: Run cargo ${{ inputs.command }}
+      if: ${{ !inputs.target }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: ${{ inputs.command }}
+        toolchain: ${{ inputs.toolchain }}
+        args: --target ${{ env.CARGO_BUILD_TARGET }} ${{ inputs.args }}
+    - name: Run cargo ${{ inputs.command }}
+      if: ${{ inputs.target }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: ${{ inputs.command }}
+        toolchain: ${{ inputs.toolchain }}
+        args: --target ${{ inputs.target }} ${{ inputs.args }}

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -1,0 +1,35 @@
+name: Install Rust
+description: Install Rust toolchain
+inputs:
+  toolchain:
+    description: Rust toolchain name
+    required: true
+  target:
+    description: Target triple to install for this toolchain
+    required: false
+  profile:
+    description: Name of the group of components to be installed for a new toolchain
+    required: false
+    default: minimal
+  components:
+    description: Comma-separated list of components to be additionally installed for a new toolchain
+    required: false
+outputs:
+  rustc-commit-hash:
+    description: Installed rustc version hash, can be used for caching purposes
+    value: ${{ steps.install-rust.outputs.rustc_hash }}
+runs:
+  using: composite
+  steps:
+    - name: Install Rust ${{ inputs.toolchain }}
+      id: install-rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        override: true
+        profile: ${{ inputs.profile }}
+        components: ${{ inputs.components }}
+    - name: Add target(s) to Rust ${{ inputs.toolchain }}
+      if: ${{ inputs.target }}
+      run: rustup target add --toolchain ${{ inputs.toolchain }} ${{ inputs.target }}
+      shell: bash

--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -1,0 +1,20 @@
+name: Install wasm-pack
+description: Install wasm-pack
+runs:
+  using: composite
+  steps:
+    - name: Install wasm-pack
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      run: |
+        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      shell: bash
+    - name: Install wasm-pack
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        $Uri = 'https://github.com/rustwasm/wasm-pack/releases/download/v0.10.2/wasm-pack-init.exe'
+        $ExeFile = 'wasm-pack-init.exe'
+        Invoke-WebRequest -Uri $Uri -OutFile $ExeFile
+        $ExeFile = Get-Item -Path .\$ExeFile
+        $Process = Start-Process -FilePath "$($ExeFile.FullName)" -Wait -NoNewWindow -PassThru
+        $Process | Select-Object -Property Id, ProcessName, ExitCode
+      shell: pwsh

--- a/.github/actions/install-wasmtime/action.yml
+++ b/.github/actions/install-wasmtime/action.yml
@@ -1,0 +1,26 @@
+name: Install Wasmtime
+description: Install Wasmtime
+runs:
+  using: composite
+  steps:
+    - name: Install Wasmtime
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      run: |
+        curl https://wasmtime.dev/install.sh -sSf | bash
+        WASMTIME_HOME="$HOME/.wasmtime"
+        echo "WASMTIME_HOME=$WASMTIME_HOME" >> $GITHUB_ENV
+        echo "$WASMTIME_HOME/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: Install Wasmtime
+      if: ${{ runner.os == 'Windows' && runner.arch == 'X64' }}
+      run: |
+        $Uri = 'https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-windows.msi'
+        $MsiFile = 'wasmtime.msi'
+        $LogFile = 'wasmtime-install.log'
+        Invoke-WebRequest -Uri $Uri -OutFile $MsiFile
+        $MsiFile = Get-Item -Path .\$MsiFile
+        $Process = Start-Process -FilePath msiexec.exe -ArgumentList "/i $($MsiFile.FullName) /qn /norestart /l*v $LogFile" -Wait -NoNewWindow -PassThru
+        $Process | Select-Object -Property Id, ProcessName, ExitCode
+        Get-Content -Path .\$LogFile
+        "$($env:ProgramFiles)\Wasmtime\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,158 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CARGO_INCREMENTAL: '0'
+  CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: -Dwarnings # https://github.com/rust-lang/cargo/issues/4423#issuecomment-404188918
+  CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: -Dwarnings # https://github.com/rust-lang/cargo/issues/4423#issuecomment-404188918
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -Dwarnings # https://github.com/rust-lang/cargo/issues/4423#issuecomment-404188918
+  RUST_BACKTRACE: short
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  clippy:
+    name: Clippy (${{ matrix.os }}) (Rust ${{ matrix.rust }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable, beta, nightly]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache Cargo home
+        uses: ./.github/actions/cache-cargo-home
+        continue-on-error: true
+      - name: Install Rust
+        id: install-rust
+        uses: ./.github/actions/install-rust
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: wasm32-unknown-unknown wasm32-wasi
+          components: clippy
+      - name: Cache Cargo build
+        uses: ./.github/actions/cache-cargo-build
+        with:
+          rustc-commit-hash: ${{ steps.install-rust.outputs.rustc-commit-hash }}
+          profile: dev
+        continue-on-error: true
+      - name: Run Clippy
+        uses: ./.github/actions/cargo
+        with:
+          command: clippy
+          toolchain: ${{ matrix.rust }}
+          args: --tests
+      - name: Run Clippy (wasm32-unknown-unknown)
+        uses: ./.github/actions/cargo
+        with:
+          command: clippy
+          toolchain: ${{ matrix.rust }}
+          target: wasm32-unknown-unknown
+          args: --tests
+      - name: Run Clippy (wasm32-wasi)
+        uses: ./.github/actions/cargo
+        with:
+          command: clippy
+          toolchain: ${{ matrix.rust }}
+          target: wasm32-wasi
+          args: --tests
+
+  test:
+    name: Test (${{ matrix.os }}) (Rust ${{ matrix.rust }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable, beta, nightly]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache Cargo home
+        uses: ./.github/actions/cache-cargo-home
+        continue-on-error: true
+      - name: Install Rust
+        id: install-rust
+        uses: ./.github/actions/install-rust
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: wasm32-unknown-unknown wasm32-wasi
+      - name: Cache Cargo build
+        uses: ./.github/actions/cache-cargo-build
+        with:
+          rustc-commit-hash: ${{ steps.install-rust.outputs.rustc-commit-hash }}
+          profile: test
+        continue-on-error: true
+      - name: Run tests
+        uses: ./.github/actions/cargo
+        with:
+          command: test
+          toolchain: ${{ matrix.rust }}
+      - name: Install wasm-pack
+        uses: ./.github/actions/install-wasm-pack
+      - name: Run tests (wasm32-unknown-unknown) (Node.js)
+        run: rustup run ${{ matrix.rust }} wasm-pack test --node
+      - name: Install cargo-wasi
+        uses: ./.github/actions/cargo
+        with:
+          command: install
+          args: cargo-wasi
+      - name: Install Wasmtime
+        uses: ./.github/actions/install-wasmtime
+      - name: Run tests (wasm32-wasi)
+        uses: ./.github/actions/cargo
+        with:
+          command: wasi
+          toolchain: ${{ matrix.rust }}
+          args: test
+      - name: Run doctests
+        uses: ./.github/actions/cargo
+        with:
+          command: test
+          toolchain: ${{ matrix.rust }}
+          args: --doc
+
+  rustdoc:
+    name: Rustdoc (Rust ${{ matrix.rust }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta, nightly]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: ./.github/actions/install-rust
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Run Rustdoc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          toolchain: ${{ matrix.rust }}
+          args: --no-deps
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: ./.github/actions/install-rust
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Run Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          toolchain: stable
+          args: -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ share = []
 skip = []
 take = []
 
+[lib]
+doctest = false
+
 [[test]]
 name = "combine"
 required-features = ["combine"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Basic [callbag][callbag-spec] factories and operators to get started with.
 Imagine a hybrid between an [Observable][tc39-observable] and an [(Async)Iterable][tc39-async-iteration], that's what
 callbags are all about. It's all done with a few simple callbacks, following the [callbag spec][callbag-spec].
 
+[![CI][ci-badge]][ci-url]
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![MIT OR Apache-2.0 licensed][license-badge]][license-url]
@@ -185,6 +186,8 @@ This library is a port of <https://github.com/staltz/callbag-basics>. Some inspi
 <https://github.com/f5io/callbag.rs>.
 
 [callbag-spec]: https://github.com/callbag/callbag
+[ci-badge]: https://github.com/teohhanhui/callbag-rs/actions/workflows/ci.yml/badge.svg
+[ci-url]: https://github.com/teohhanhui/callbag-rs/actions/workflows/ci.yml
 [crates-badge]: https://img.shields.io/crates/v/callbag
 [crates-url]: https://crates.io/crates/callbag
 [docs-badge]: https://img.shields.io/docsrs/callbag

--- a/src/combine.rs
+++ b/src/combine.rs
@@ -16,7 +16,7 @@ use crate::{Message, Source};
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use arc_swap::ArcSwap;
 /// use async_nursery::Nursery;
 /// use std::{sync::Arc, time::Duration};

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -11,7 +11,7 @@
 ///
 /// Create a source with `pipe!`, then pass it to a [`for_each`]:
 ///
-/// ```
+/// ```no_run
 /// use arc_swap::ArcSwap;
 /// use async_nursery::Nursery;
 /// use std::{sync::Arc, time::Duration};
@@ -60,6 +60,7 @@
 ///         "X6,Y1",
 ///         "X7,Y1",
 ///         "X8,Y1",
+///         "X9,Y1",
 ///         "X9,Y2",
 ///     ]
 /// );
@@ -67,7 +68,7 @@
 ///
 /// Or use `pipe!` to go all the way from source to sink:
 ///
-/// ```
+/// ```no_run
 /// use arc_swap::ArcSwap;
 /// use async_nursery::Nursery;
 /// use std::{sync::Arc, time::Duration};
@@ -115,6 +116,7 @@
 ///         "X6,Y1",
 ///         "X7,Y1",
 ///         "X8,Y1",
+///         "X9,Y1",
 ///         "X9,Y2",
 ///     ]
 /// );
@@ -125,7 +127,7 @@
 /// To use `pipe!` inside another `pipe!`, you need to give the inner `pipe!` an argument, e.g.
 /// `|s| pipe!(s, ...`:
 ///
-/// ```
+/// ```no_run
 /// use arc_swap::ArcSwap;
 /// use async_nursery::Nursery;
 /// use std::{sync::Arc, time::Duration};
@@ -176,6 +178,7 @@
 ///         "X6,Y1",
 ///         "X7,Y1",
 ///         "X8,Y1",
+///         "X9,Y1",
 ///         "X9,Y2",
 ///     ]
 /// );
@@ -183,7 +186,7 @@
 ///
 /// This means you can use `pipe!` to create a new operator:
 ///
-/// ```
+/// ```no_run
 /// use arc_swap::ArcSwap;
 /// use async_nursery::Nursery;
 /// use std::{sync::Arc, time::Duration};
@@ -237,6 +240,7 @@
 ///         "X6,Y1",
 ///         "X7,Y1",
 ///         "X8,Y1",
+///         "X9,Y1",
 ///         "X9,Y2",
 ///     ]
 /// );


### PR DESCRIPTION
- [x] Some doctests failing is a known issue.

    It's because of the unordered nature of the tasks being run (in `async_nursery`): https://docs.rs/async_nursery/0.3.1/async_nursery/#differences-with-futuresunordered
    
    But what's the best way to handle this? Add `no_run`?

    Should we guarantee ordering, i.e. when 2 timers have the "same" delay duration, a timer created first should always fire first?

- [ ] Some tests failing on Linux:

    - https://github.com/teohhanhui/callbag-rs/runs/4661124395?check_suite_focus=true#step:4:304

    The failures seem to be intermittent, so this looks like a race condition. Hopefully it's just a problem with the test.

    Unable to reproduce on my machine.

- [ ] Some tests failing on macOS:

    - https://github.com/teohhanhui/callbag-rs/runs/4676226803?check_suite_focus=true#step:6:137
    - https://github.com/teohhanhui/callbag-rs/runs/4676226803?check_suite_focus=true#step:6:243
    - https://github.com/teohhanhui/callbag-rs/runs/4712691284?check_suite_focus=true#step:6:190

    Unable to reproduce on my machine (don't have a Mac).